### PR TITLE
Support warning lines with "WARN"

### DIFF
--- a/ftdetect/log.vim
+++ b/ftdetect/log.vim
@@ -1,1 +1,11 @@
 au BufNewFile,BufRead *.log set filetype=log
+au BufNewFile,BufRead *.log.1 set filetype=log
+au BufNewFile,BufRead *.log.2 set filetype=log
+au BufNewFile,BufRead *.log.3 set filetype=log
+au BufNewFile,BufRead *.log.4 set filetype=log
+au BufNewFile,BufRead *.log.5 set filetype=log
+au BufNewFile,BufRead *.log.6 set filetype=log
+au BufNewFile,BufRead *.log.7 set filetype=log
+au BufNewFile,BufRead *.log.8 set filetype=log
+au BufNewFile,BufRead *.log.9 set filetype=log
+au BufNewFile,BufRead *.log.10 set filetype=log

--- a/syntax/log.vim
+++ b/syntax/log.vim
@@ -3,6 +3,7 @@
 " Maintainer:       Alex Dzyoba <avd@reduct.ru>
 " Latest Revision:  2013-03-08
 " Changes:          2013-03-08 Initial version
+"                   2016-09-01 Changes by jquintus
 
 " Based on messages.vim - syntax file for highlighting kernel messages
 
@@ -11,7 +12,7 @@ if exists("b:current_syntax")
 endif
 
 syn match log_error 	'\c.*\<\(FATAL\|ERROR\|ERRORS\|FAIL\|FAILED\|FAILURE\).*'
-syn match log_warning 	'\c.*\<\(WARNING\|DELETE\|DELETING\|DELETED\|RETRY\|RETRYING\).*'
+syn match log_warning 	'\c.*\<\(WARN\|WARNING\|DELETE\|DELETING\|DELETED\|RETRY\|RETRYING\).*'
 syn region log_string 	start=/'/ end=/'/ end=/$/ skip=/\\./
 syn region log_string 	start=/"/ end=/"/ skip=/\\./
 syn match log_number 	'0x[0-9a-fA-F]*\|\[<[0-9a-f]\+>\]\|\<\d[0-9a-fA-F]*'


### PR DESCRIPTION
If you're interested I made some small changes to your great syntax script.  Basically I did two things:'

:one: Added highlighting for "WARN", for example:

```
 08/19/2016 15:28:02.467 | 51 | WARN  | Something interesting happened here
```

:two: Support log files that end with numbers.  A lot of my logs roll over and get named to mylog.log.1, mylog.log.2
